### PR TITLE
Add run_dir option, fix checkpoint bug

### DIFF
--- a/tests/tf_multigpu.py
+++ b/tests/tf_multigpu.py
@@ -42,7 +42,7 @@ if args.dummy_data:
     # Use random data
     print('Using random data')
     def generate_dummy_dataset(num_samples=1000, image_shape=(28, 28), num_classes=10):
-        images = np.random.rand(num_samples, *image_shape)
+        images = np.random.rand(num_samples, *image_shape, 1)
         labels = np.random.randint(0, num_classes, size=num_samples)
 
         return images, labels


### PR DESCRIPTION
Adds an option to run in a user-supplied directory (better isolation for concurrent runs, which previously would write checkpoints to the same directory). Also fixes a bug with the checkpoint pathname, and updates the shape of dummy data to work with TF 2.6.0 as well.

This version is now passing in reframe for all my tested modules/containers, PR for that to follow once this gets merged